### PR TITLE
change: test: TravisからPHP5.6を削除,php72以降でUnitTestでWarningが出るため修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendors/autoload.php">
+    <php>
+        <ini name="memory_limit" value="-1"/>
+    </php>
+    <php>
+        <ini name="error_reporting" value="0"/>
+    </php>
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".ctp">app/Plugin/SiteManager</directory>


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1588